### PR TITLE
Sette crossOriginEmbedderPolicy: false i helmet

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const server = express();
 server.use(
     helmet({
         contentSecurityPolicy: false,
+        crossOriginEmbedderPolicy: false,
     })
 );
 server.use(compression());


### PR DESCRIPTION
Sette tilbake verdi til det som var default tidligere. Fjerner errors i console.